### PR TITLE
feat: add UpdateOne method for partial field updates

### DIFF
--- a/sqlr/helpers.go
+++ b/sqlr/helpers.go
@@ -15,6 +15,12 @@ func Update[T any](data *T) error {
 	return instance.gormDB.Save(data).Error
 }
 
+// UpdateOne ...
+func UpdateOne[T any](scope func(db *gorm.DB) *gorm.DB, updates map[string]any) error {
+	var model T
+	return instance.gormDB.Model(&model).Scopes(scope).Updates(updates).Error
+}
+
 // Delete ...
 func Delete[T any](scopes ...func(db *gorm.DB) *gorm.DB) error {
 	return instance.gormDB.Scopes(scopes...).Delete(new(T)).Error


### PR DESCRIPTION
## Add UpdateOne function for partial updates

### Changes
- Added `UpdateOne[T any]` function to support partial field updates with scope conditions

### Motivation
The existing `Update` function uses `Save()` which updates all fields. For cases where we only need to update specific fields based on conditions (e.g., updating organization settings by organization_id), we need a more targeted approach.

### Usage Example
```go
err := sqlr.UpdateOne[models.OrganizationSettings](
    func(db *gorm.DB) *gorm.DB {
        return db.Where("organization_id = ?", orgID)
    },
    map[string]any{
        "logo_url": "https://example.com/logo.png",
        "updated_at": time.Now(),
    },
)
```

### Benefits
- Allows partial updates without loading the entire model
- More efficient for updating specific fields
- Maintains consistency with existing scope-based API pattern